### PR TITLE
Make Formatter usable as an AMD module

### DIFF
--- a/lib/formatter.js
+++ b/lib/formatter.js
@@ -6,11 +6,11 @@
  * thanks to digitalBush/jquery.maskedinput for some of the trickier
  * keycode handling
  */ 
-
-;(function (window, document, undefined) {
-
-// Expose to window
-if (typeof window !== 'undefined') { window.Formatter = Formatter; }
+;(function (name, context, definition) {
+  if (typeof module !== 'undefined' && module.exports) { module.exports = definition(); }
+  else if (typeof define === 'function' && define.amd) { define(definition); }
+  else { context[name] = definition(); }
+})('Formatter', this, function () {
 
 // Defaults
 var defaults = {
@@ -620,4 +620,6 @@ utils.isModifier = function (evt) {
   return evt.ctrlKey || evt.altKey || evt.metaKey;
 };
 
-})(window, document);
+return Formatter;
+
+});


### PR DESCRIPTION
Defines Formatter as an AMD module if an AMD compatible define function is found in scope. Does the same for CommonJS and falls back to defining it as `window['Formatter']`. Tests all still pass.
