### PR TITLE
Allow user to completely empty a field when persistent is false

### DIFF
--- a/src/formatter.js
+++ b/src/formatter.js
@@ -260,8 +260,10 @@ Formatter.prototype._formatValue = function () {
   this._removeChars();
   // Validate inpts
   this._validateInpts();
-  // Add formatted characters
-  this._addChars();
+  if (this.newPos > 0 || this.opts.persistent) {
+    // Add formatted characters
+    this._addChars();
+  }
 
   // Set vakye and adhere to maxLength 
   this.el.value = this.val.substr(0, this.mLength);


### PR DESCRIPTION
When using persistent=false, and using a pattern that starts with a formatted characters, for example `({{999}})`, the user is not able to completely empty the field; there will always be a character left in there.
This makes it complicated to validate posted values, as we would need to treat "(" the same as an empty field.
This change will allow the user to remove this last character.
