### PR TITLE
Disable caret positionning on resetPattern

### DIFF
--- a/src/formatter.js
+++ b/src/formatter.js
@@ -101,8 +101,7 @@ Formatter.addInptType = function (char, reg) {
 
 //
 // @public
-// Handler called on all keyDown strokes. All keys trigger
-// this handler. Only process delete keys.
+// Apply the given pattern to the current input without moving caret.
 //
 Formatter.prototype.resetPattern = function (str) {
   // Update opts to hold new pattern
@@ -125,7 +124,7 @@ Formatter.prototype.resetPattern = function (str) {
   this.inpts   = parsed.inpts;
 
   // Format on start
-  this._processKey('', false);
+  this._processKey('', false, true);
 };
 
 //
@@ -202,7 +201,7 @@ Formatter.prototype._focus = function (evt) {
 // @private
 // Using the provided key information, alter el value.
 //
-Formatter.prototype._processKey = function (chars, delKey) {
+Formatter.prototype._processKey = function (chars, delKey,ingoreCaret) {
   // Get current state
   this.sel = inptSel.get(this.el);
   this.val = this.el.value;
@@ -238,7 +237,7 @@ Formatter.prototype._processKey = function (chars, delKey) {
   }
 
   // Format el.value (also handles updating caret position)
-  this._formatValue();
+  this._formatValue(ingoreCaret);
 };
 
 //
@@ -273,24 +272,26 @@ Formatter.prototype._nextPos = function () {
 //
 // @private
 // Alter element value to display characters matching the provided
-// instance pattern. Also responsible for updatin
+// instance pattern. Also responsible for updating
 //
-Formatter.prototype._formatValue = function () {
+Formatter.prototype._formatValue = function (ignoreCaret) {
   // Set caret pos
   this.newPos = this.sel.end + this.delta;
 
   // Remove all formatted chars from val
   this._removeChars();
-  // Validate inpts
+  // Validate inputs
   this._validateInpts();
   // Add formatted characters
   this._addChars();
 
-  // Set vakye and adhere to maxLength 
+  // Set value and adhere to maxLength 
   this.el.value = this.val.substr(0, this.mLength);
 
   // Set new caret position
-  inptSel.set(this.el, this.newPos);
+  if ((typeof ignoreCaret) === 'undefined' || ignoreCaret === false) {
+    inptSel.set(this.el, this.newPos);
+  }
 };
 
 //


### PR DESCRIPTION
Main issue : there is no way to format the input when it is updated with 'val()' function.
Calling 'resetPattern' is the good solution, unfortunally the input get focus; this cause troubles on IE7 (inputs are blinking continuously) and on modern browsers since focus are stolen.
So I disabled the caret manipulation on 'resetPattern'
