### PR TITLE
Linting fixes.

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -7,7 +7,9 @@ module.exports = function(grunt) {
         'Gruntfile.js',
         'src/**/*.js',
         'test/**/*.js',
-        'test/**/**/*.js'
+        'test/**/**/*.js',
+        'lib/formatter.js',
+        'lib/jquery.formatter.js'
       ],
       options: {
         ignores: [
@@ -17,6 +19,8 @@ module.exports = function(grunt) {
           'src/tmpls/jquery.outro.js'
         ],
         force: true,
+        es3: true,
+        smarttabs: true,
         // Bad line breaking before '?'.
         '-W014': true,
         // Expected a conditional expression and instead saw an assignment.
@@ -88,6 +92,6 @@ module.exports = function(grunt) {
   grunt.loadNpmTasks('grunt-contrib-concat');
   grunt.loadNpmTasks('grunt-contrib-uglify');
 
-  // Tasks    
+  // Tasks
   grunt.registerTask('default', ['jshint', 'concat', 'uglify']);
 };

--- a/src/formatter.js
+++ b/src/formatter.js
@@ -39,7 +39,7 @@ function Formatter(el, opts) {
 
   // Make sure we have an element. Make accesible to instance
   self.el = el;
-  if (!self.el) { 
+  if (!self.el) {
     throw new TypeError('Must provide an existing element');
   }
 
@@ -95,8 +95,8 @@ function Formatter(el, opts) {
 // @public
 // Add new char
 //
-Formatter.addInptType = function (char, reg) {
-  inptRegs[char] = reg;
+Formatter.addInptType = function (chr, reg) {
+  inptRegs[chr] = reg;
 };
 
 //
@@ -107,7 +107,7 @@ Formatter.addInptType = function (char, reg) {
 Formatter.prototype.resetPattern = function (str) {
   // Update opts to hold new pattern
   this.opts.pattern = str;
-  
+
   // Get current state
   this.sel = inptSel.get(this.el);
   this.val = this.el.value;
@@ -182,14 +182,14 @@ Formatter.prototype._paste = function (evt) {
 // @private
 // Handle called on focus event.
 //
-Formatter.prototype._focus = function (evt) {
+Formatter.prototype._focus = function () {
   // Wrapped in timeout so that we can grab input selection
   var self = this;
   setTimeout(function () {
     // Grab selection
     var selection = inptSel.get(self.el);
     // Char check
-    var isAfterStart = selection.end > self.focus;
+    var isAfterStart = selection.end > self.focus,
         isFirstChar  = selection.end === 0;
     // If clicked in front of start, refocus to start
     if (isAfterStart || isFirstChar) {
@@ -286,7 +286,7 @@ Formatter.prototype._formatValue = function () {
   // Add formatted characters
   this._addChars();
 
-  // Set vakye and adhere to maxLength 
+  // Set vakye and adhere to maxLength
   this.el.value = this.val.substr(0, this.mLength);
 
   // Set new caret position
@@ -362,7 +362,7 @@ Formatter.prototype._validateInpts = function () {
 // Loop over val and add formatted chars as necessary
 //
 Formatter.prototype._addChars = function () {
-  if (this.opts.persistent) { 
+  if (this.opts.persistent) {
     // Loop over all possible characters
     for (var i = 0; i <= this.mLength; i++) {
       if (!this.val.charAt(i)) {
@@ -394,8 +394,8 @@ Formatter.prototype._addChars = function () {
 //
 Formatter.prototype._addChar = function (i) {
   // If char exists at position
-  var char = this.chars[i];
-  if (!char) { return true; }
+  var chr = this.chars[i];
+  if (!chr) { return true; }
 
   // If chars are added in between the old pos and new pos
   // we need to increment pos and delta
@@ -416,5 +416,5 @@ Formatter.prototype._addChar = function (i) {
   }
 
   // Update value
-  this.val = utils.addChars(this.val, char, i);
+  this.val = utils.addChars(this.val, chr, i);
 };

--- a/src/tmpls/jquery.outro.js
+++ b/src/tmpls/jquery.outro.js
@@ -1,4 +1,4 @@
-// A really lightweight plugin wrapper around the constructor, 
+// A really lightweight plugin wrapper around the constructor,
 // preventing against multiple instantiations
 var pluginName = 'formatter';
 
@@ -8,7 +8,7 @@ $.fn[pluginName] = function (options) {
 	if (typeof options == 'object') {
 	  this.each(function () {
 	    if (!$.data(this, 'plugin_' + pluginName)) {
-	      $.data(this, 'plugin_' + pluginName, 
+	      $.data(this, 'plugin_' + pluginName,
 	      new Formatter(this, options));
 	    }
 	  });
@@ -22,15 +22,15 @@ $.fn[pluginName] = function (options) {
       if (formatted) { formatted.resetPattern(str); }
     });
     // Chainable please
-    return this
+    return this;
   };
 
   // Chainable please
   return this;
 };
 
-$.fn[pluginName].addInptType = function (char, regexp) {
-  Formatter.addInptType(char, regexp);
+$.fn[pluginName].addInptType = function (chr, regexp) {
+  Formatter.addInptType(chr, regexp);
 };
 
 

--- a/test/fake-user/keys.js
+++ b/test/fake-user/keys.js
@@ -4,7 +4,7 @@
  * (C) 2013 First Opinion
  * MIT LICENCE
  *
- */ 
+ */
 
 module.exports = keys = {};
 
@@ -13,27 +13,27 @@ module.exports = keys = {};
 // Helper method to fix characters that cannot
 // be store as a json key
 //
-var fixChar = function (char) {
-  if (char == '"') {
-    char = 'doublequote';
-  } else if (char == "\\") {
-    char = 'forwardslash';
+var fixChar = function (chr) {
+  if (chr == '"') {
+    chr = 'doublequote';
+  } else if (chr == "\\") {
+    chr = 'forwardslash';
   }
-  return char;
+  return chr;
 };
 
 //
 // Method to get key press obj
 //
-keys.getPress = function (char) {
-  return keys.press[fixChar(char)];
+keys.getPress = function (chr) {
+  return keys.press[fixChar(chr)];
 };
 
 //
 // Method to get key down obj
 //
-keys.getDown = function (char) {
-  return keys.down[fixChar(char)];
+keys.getDown = function (chr) {
+  return keys.down[fixChar(chr)];
 };
 
 

--- a/test/fake-user/user.js
+++ b/test/fake-user/user.js
@@ -4,7 +4,7 @@
  * (C) 2013 First Opinion
  * MIT LICENCE
  *
- */ 
+ */
 
 // stdlib
 var EventEmitter = require('events').EventEmitter;
@@ -29,11 +29,11 @@ User.prototype.constructor = User;
 //
 // Mock keyboard input
 //
-User.prototype.key = function (char, opts) {
+User.prototype.key = function (chr, opts) {
   // Determine what we should trigger by looking for
   // existence within keys.press, and keys.down
-  var keyPress = keys.getPress(char),
-      keyDown  = keys.getDown(char);
+  var keyPress = keys.getPress(chr),
+      keyDown  = keys.getDown(chr);
 
   // If no opts passed, create blank obj
   if (!opts) { opts = {}; }


### PR DESCRIPTION
I've fixed some linting issues that were caught by our closure compiler setup. The code used `char` as a variable in several places. This caused an error since it's considered a reserved word in EcmaScript 3. I also fixed an undeclared variable and a missing semicolon.
Lastly, I added some options to the grunt config so that these types of errors can be caught going forward. I also added the concatenated files to the list of linted files since you can't lint the concatenation templates on their own.
