### PR TITLE
Backspace should remove placeholder + preceeding char

### DIFF
--- a/src/formatter.js
+++ b/src/formatter.js
@@ -245,7 +245,7 @@ Formatter.prototype._processKey = function (chars, delKey, ignoreCaret) {
     // Increase the backspace distance for every
     // placeholder character at the end of the selection
     var backspaceDistance = 1;
-    while (this.chars[this.sel.end - backspaceDistance]) {
+    while (!this.opts.persistent && this.chars[this.sel.end - backspaceDistance]) {
       backspaceDistance++;
     }
 

--- a/src/formatter.js
+++ b/src/formatter.js
@@ -241,9 +241,16 @@ Formatter.prototype._processKey = function (chars, delKey, ignoreCaret) {
 
   // or Backspace and not at start
   } else if (delKey && this.sel.begin - 1 >= 0) {
+    
+    // Increase the backspace distance for every
+    // placeholder character at the end of the selection
+    var backspaceDistance = 1;
+    while (this.chars[this.sel.end - backspaceDistance]) {
+      backspaceDistance++;
+    }
 
     // Always have a delta of at least -1 for the character being deleted.
-    this.val = utils.removeChars(this.val, this.sel.end -1, this.sel.end);
+    this.val = utils.removeChars(this.val, this.sel.end - backspaceDistance, this.sel.end);
     this.delta -= 1;
 
   // or Backspace and at start - exit

--- a/test/formatter.js
+++ b/test/formatter.js
@@ -342,10 +342,10 @@ describe('formatter.js', function () {
       });
     });
 
-    it('Should remove a format character when it is the last character on backspace key', function (done) {
+    it('Should remove a format character and preceeding character when it is the last character on backspace key', function (done) {
       fakey.str(el, '123', function () {
         fakey.key(el, 'backspace', function () {
-          assert.equal(formatted.el.value, '(123');
+          assert.equal(formatted.el.value, '(12');
           done();
         });
       });


### PR DESCRIPTION
If your cursor is immediately following a placeholder char, hitting backspace should remove the placeholder and the char preceding it.

Fixes https://github.com/firstopinion/formatter.js/issues/75
