### PR TITLE
backspace fix in IE8

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -96,7 +96,7 @@ utils.isDelKeyDown = function (which, keyCode) {
     'delete': { 'which': 46, 'keyCode': 46 }
   };
 
-  return utils.getMatchingKey(which, keyCode, keys);
+  return utils.getMatchingKey(which || keyCode, keyCode, keys);
 };
 
 //
@@ -108,7 +108,7 @@ utils.isDelKeyPress = function (which, keyCode) {
     'delete': { 'which': 0, 'keyCode': 46 }
   };
 
-  return utils.getMatchingKey(which, keyCode, keys);
+  return utils.getMatchingKey(which || keyCode, keyCode, keys);
 };
 
 // //


### PR DESCRIPTION
event.which is undefined under IE8, so formatter.js can't notice that backspace was pressed
