### PR TITLE
Fix incorrect focus on 'persistent': true

### DIFF
--- a/dist/jquery.formatter.js
+++ b/dist/jquery.formatter.js
@@ -494,7 +494,7 @@ var formatter = function (patternMatcher, inptSel, utils) {
       // Persistence
       if (self.opts.persistent) {
         // Format on start
-        self._processKey('', false);
+        self._processKey('', false, true);
         self.el.blur();
         // Add Listeners
         utils.addListener(self.el, 'focus', function (evt) {


### PR DESCRIPTION
If persistent is set to true this code is executed:
497 - self._processKey('', false);
Then at the end of Formatter.prototype._processKey this code is executed with ignoreCaret not set so it's Undefined:
647 - this._formattValue(ignoreCaret);
Finally this code who changes screen position, if ignoreCaret is False or Undefined, is executed:
694 - inptSel.set(this.el,this.newPos);

So it's enough to change line 497 to self._processKey('', false, true); to fix this.
